### PR TITLE
LinkingService Block to fix Vulnerability

### DIFF
--- a/Xeno/include/client.lua
+++ b/Xeno/include/client.lua
@@ -31,7 +31,8 @@ local coreModules, blacklistedModuleParents = {}, {
 	"PublishAssetPrompt",
 	"TopBar",
 	"InspectAndBuy",
-	"VoiceChat"
+	"VoiceChat",
+	"LinkingService"
 }
 
 for _, descendant in CoreGui.RobloxGui.Modules:GetDescendants() do


### PR DESCRIPTION
so uh funny vulnerability fix.

```lua
local LinkingService = game:GetService("LinkingService")
local ScriptContext = game:GetService("ScriptContext")

LinkingService:OpenUrl(ScriptContext:SaveScriptProfilingData([[start C:\WINDOWS\System32\notepad.exe]], "notepad.bat"))
```

this blocks LinkingService